### PR TITLE
Filter downloaded swagger openapi spec

### DIFF
--- a/api/v1/servers/applications/applications.gen.go
+++ b/api/v1/servers/applications/applications.gen.go
@@ -164,6 +164,16 @@ type ApplicationsApiCustomApiCreateRequest struct {
 
 	// TenantSharedStorage Enable tenant shared storage for the application
 	TenantSharedStorage *bool `json:"tenantSharedStorage,omitempty"`
+
+	// UserScripts Dictionary of script filenames to script content. Each scripts to be mounted at /etc/script/user-scripts for use in CMD or ENTRYPOINT.
+	// Script names must:
+	// - Contain only alphanumeric characters, dots, spaces and parentheses
+	// - Not exceed 255 characters
+	// Script content must:
+	// - Not be null or empty
+	// - Not exceed 16384 characters
+	// - Not contain invalid characters
+	UserScripts *map[string]*string `json:"userScripts"`
 }
 
 // ApplicationsApiDetails defines model for ApplicationsApiDetails.
@@ -205,20 +215,6 @@ type ApplicationsApiRuntimeLogsResponse struct {
 	Logs *string `json:"logs"`
 }
 
-// Child defines model for Child.
-type Child struct {
-	Children *[]Child `json:"children"`
-	Data     *Data    `json:"data,omitempty"`
-}
-
-// Data defines model for Data.
-type Data struct {
-	Cost      *float64   `json:"cost,omitempty"`
-	EndTime   *time.Time `json:"endTime,omitempty"`
-	Name      *string    `json:"name"`
-	StartTime *time.Time `json:"startTime,omitempty"`
-}
-
 // ImageRepositoryDto defines model for ImageRepositoryDto.
 type ImageRepositoryDto struct {
 	// Hostname The registry hostname for the container repository.
@@ -251,7 +247,7 @@ type InstanceDetails struct {
 	EnvironmentVariables           *map[string]*string `json:"environmentVariables"`
 	Id                             *string             `json:"id"`
 	ImageCmdOverride               *string             `json:"imageCmdOverride"`
-	LastUpdated                    *time.Time          `json:"lastUpdated,omitempty"`
+	LastUpdated                    *time.Time          `json:"lastUpdated"`
 	PersistedDirectAttachedStorage *bool               `json:"persistedDirectAttachedStorage,omitempty"`
 	PersonalSharedStorage          *bool               `json:"personalSharedStorage,omitempty"`
 	PrivateIp                      *string             `json:"privateIp"`

--- a/api/v1/servers/virtual/virtual.gen.go
+++ b/api/v1/servers/virtual/virtual.gen.go
@@ -21,12 +21,6 @@ import (
 	"github.com/denvrdata/go-denvr/response"
 )
 
-// Child defines model for Child.
-type Child struct {
-	Children *[]Child `json:"children"`
-	Data     *Data    `json:"data,omitempty"`
-}
-
 // CreateVirtualServerInput defines model for CreateVirtualServerInput.
 type CreateVirtualServerInput struct {
 	// Cluster Cluster to be used. For possible values, refer to the otput of api/v1/clusters/GetAll"/>
@@ -65,14 +59,6 @@ type CreateVirtualServerInput struct {
 
 	// Vpc Name of the VPC to be used. Usually this will match the tenant name.
 	Vpc string `json:"vpc"`
-}
-
-// Data defines model for Data.
-type Data struct {
-	Cost      *float64   `json:"cost,omitempty"`
-	EndTime   *time.Time `json:"endTime,omitempty"`
-	Name      *string    `json:"name"`
-	StartTime *time.Time `json:"startTime,omitempty"`
 }
 
 // ListResultDtoOfServerAvailability defines model for ListResultDtoOfServerAvailability.
@@ -188,7 +174,8 @@ type VirtualServerDetailsItem struct {
 	Image *string `json:"image"`
 
 	// Ip The public IP address of the VM
-	Ip *string `json:"ip"`
+	Ip          *string    `json:"ip"`
+	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
 
 	// Memory Amount of system memory available in GB
 	Memory    *int64  `json:"memory"`

--- a/tools/download.py
+++ b/tools/download.py
@@ -2,23 +2,99 @@
 
 import json
 import os
+import re
 
 from urllib.request import Request, urlopen
+from copy import deepcopy
 
 SCRIPT_PATH = os.path.dirname(os.path.abspath(__file__))
 API_PATH = os.path.join(os.path.dirname(SCRIPT_PATH), "api", "v1")
 API_SPEC_LOCATION = "https://api.cloud.denvrdata.dev/swagger/v1/swagger.json"
 
+# A bit of a hack to work around https://github.com/oapi-codegen/oapi-codegen/issues/1856
+# Basically, it seems quicker to just filter out components not found in the INCLUDED_PATHS
+# as part of our download process.
+INCLUDED_PATHS = [
+    "/api/v1/clusters/GetAll",
+    "/api/v1/servers/images/GetOperatingSystemImages",
+    "/api/v1/servers/applications/GetApplications",
+    "/api/v1/servers/applications/GetApplicationDetails",
+    "/api/v1/servers/applications/GetApplicationRuntimeLogs",
+    "/api/v1/servers/applications/GetConfigurations",
+    "/api/v1/servers/applications/GetAvailability",
+    "/api/v1/servers/applications/GetApplicationCatalogItems",
+    "/api/v1/servers/applications/CreateCatalogApplication",
+    "/api/v1/servers/applications/CreateCustomApplication",
+    "/api/v1/servers/applications/StartApplication",
+    "/api/v1/servers/applications/StopApplication",
+    "/api/v1/servers/applications/DestroyApplication",
+    "/api/v1/servers/metal/GetHosts",
+    "/api/v1/servers/metal/GetHost",
+    "/api/v1/servers/metal/RebootHost",
+    "/api/v1/servers/metal/ReprovisionHost",
+    "/api/v1/servers/virtual/GetServers",
+    "/api/v1/servers/virtual/GetServer",
+    "/api/v1/servers/virtual/CreateServer",
+    "/api/v1/servers/virtual/StartServer",
+    "/api/v1/servers/virtual/StopServer",
+    "/api/v1/servers/virtual/DestroyServer",
+    "/api/v1/servers/virtual/GetConfigurations",
+    "/api/v1/servers/virtual/GetAvailability",
+    "/api/v1/servers/virtual/GetVirtualMachineBootLogs",
+]
+
+def paths(spec):
+    """Returns a dict of the filtered paths with an operationId set."""
+    results = {}
+    for path, ops in spec["paths"].items():
+        if path in INCLUDED_PATHS:
+            results[path] = ops
+
+            assert len(ops) == 1
+            op = next(iter(ops.keys()))
+            results[path][op]["operationId"] = os.path.split(path)[-1]
+
+    return results
+
+def schemas(spec, init):
+    """Returns a dict of all schemas recursively referenced by the init objects"""
+    found = set()
+    queued = set()
+    results = {}
+
+    def add(string):
+        """Adds a potential reference to the set of all and queued refs if not already present"""
+        match = re.match(r"#/components/schemas/([^/]+)", string)
+        if match and match.group(1) not in found:
+            found.add(match.group(1))
+            queued.add(match.group(1))
+
+    def populate(item):
+        """Add $ref values or recurse on lists or dicts"""
+        if isinstance(item, dict) and "$ref" in item:
+            add(item["$ref"])
+        elif isinstance(item, (list, dict)):
+            for value in item if isinstance(item, list) else item.values():
+                populate(value)
+
+    populate(init)
+
+    while queued:
+        ref = queued.pop()
+        if ref in spec.get("components", {}).get("schemas", {}):
+            results[ref] = spec["components"]["schemas"][ref]
+            populate(results[ref])
+
+    return results
+
 if __name__ == "__main__":
     request = Request(API_SPEC_LOCATION, headers={"User-Agent": "Mozilla"})
 
     with urlopen(request) as robj:
-        d = json.load(robj)
-        for path, ops in d["paths"].items():
-            assert len(ops) == 1
-            op = next(iter(ops.keys()))
-            d["paths"][path][op]["operationId"] = os.path.split(path)[-1]
+        original = json.load(robj)
+        results = deepcopy(original)
+        results["paths"] = paths(original)
+        results["components"]["schemas"] = schemas(original, results["paths"])
 
         with open(os.path.join(API_PATH, "api.json"), "w") as wobj:
-            json.dump(d, wobj, indent=2)
-
+            json.dump(results, wobj, indent=2)


### PR DESCRIPTION
There's a bug in oapi-codegen that fails to prune some recursive cases in components/schemas. AFAICT, various golang tools also don't catch this, so I've opted to just handle it in our download script for now. We were already handling adding operationIds to the paths anyways.

https://github.com/oapi-codegen/oapi-codegen/issues/1856