### PR TITLE
Update the download.py script to also drop date-time formatting.

### DIFF
--- a/api/v1/servers/applications/applications.gen.go
+++ b/api/v1/servers/applications/applications.gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/oapi-codegen/runtime"
 
@@ -56,12 +55,12 @@ type ApplicationsApiCatalogItem struct {
 
 // ApplicationsApiCatalogItemVersion defines model for ApplicationsApiCatalogItemVersion.
 type ApplicationsApiCatalogItemVersion struct {
-	ImageLastPushDate *time.Time `json:"imageLastPushDate"`
-	ImageUrl          *string    `json:"imageUrl"`
-	LaunchType        *string    `json:"launchType"`
-	Name              *string    `json:"name"`
-	Platform          *string    `json:"platform"`
-	ReleaseNotesUrl   *string    `json:"releaseNotesUrl"`
+	ImageLastPushDate *string `json:"imageLastPushDate"`
+	ImageUrl          *string `json:"imageUrl"`
+	LaunchType        *string `json:"launchType"`
+	Name              *string `json:"name"`
+	Platform          *string `json:"platform"`
+	ReleaseNotesUrl   *string `json:"releaseNotesUrl"`
 }
 
 // ApplicationsApiCommandRequest defines model for ApplicationsApiCommandRequest.
@@ -242,12 +241,12 @@ type InstanceDetails struct {
 	// ContainerUid User ID (UID) for running container when not using root privileges
 	ContainerUid                   *int32              `json:"containerUid"`
 	CreatedBy                      *string             `json:"createdBy"`
-	CreationTime                   *time.Time          `json:"creationTime,omitempty"`
+	CreationTime                   *string             `json:"creationTime,omitempty"`
 	Dns                            *string             `json:"dns"`
 	EnvironmentVariables           *map[string]*string `json:"environmentVariables"`
 	Id                             *string             `json:"id"`
 	ImageCmdOverride               *string             `json:"imageCmdOverride"`
-	LastUpdated                    *time.Time          `json:"lastUpdated"`
+	LastUpdated                    *string             `json:"lastUpdated"`
 	PersistedDirectAttachedStorage *bool               `json:"persistedDirectAttachedStorage,omitempty"`
 	PersonalSharedStorage          *bool               `json:"personalSharedStorage,omitempty"`
 	PrivateIp                      *string             `json:"privateIp"`

--- a/api/v1/servers/virtual/virtual.gen.go
+++ b/api/v1/servers/virtual/virtual.gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/oapi-codegen/runtime"
 
@@ -174,8 +173,8 @@ type VirtualServerDetailsItem struct {
 	Image *string `json:"image"`
 
 	// Ip The public IP address of the VM
-	Ip          *string    `json:"ip"`
-	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
+	Ip          *string `json:"ip"`
+	LastUpdated *string `json:"lastUpdated,omitempty"`
 
 	// Memory Amount of system memory available in GB
 	Memory    *int64  `json:"memory"`

--- a/tools/download.py
+++ b/tools/download.py
@@ -70,8 +70,15 @@ def schemas(spec, init):
             queued.add(match.group(1))
 
     def populate(item):
-        """Add $ref values or recurse on lists or dicts"""
-        if isinstance(item, dict) and "$ref" in item:
+        """
+        Add $ref values or recurse on lists or dicts.
+
+        NOTE: We also remove date-time formats to avoid RFC3339 parsing errors when the server returns
+        strings that are missing timezones. https://github.com/denvrdata/DenvrDashboard/issues/3048
+        """
+        if isinstance(item, dict) and item.get("type") == "string" and item.get("format") == "date-time":
+            del item["format"]
+        elif isinstance(item, dict) and "$ref" in item:
             add(item["$ref"])
         elif isinstance(item, (list, dict)):
             for value in item if isinstance(item, list) else item.values():


### PR DESCRIPTION
Currently, the server returns datetime strings that cannot be parsed by the rather strict go RFC3339 `time.Time` parser.

Why this solution?

- I tried fixing the formatting before unmarshalling, but that code used regex and was rather brittle.
- The correct approach would be to use a custom wrapper type and implement the correct marshalling interface on it. However, I'd rather not introduce yet more custom types, and we'd still need an overlay x-go-type for the oapi-codegen part.
- We could also create our own custom recursive unmarshalling alg that detects `time.Time` in the target type and applies custom parsing. This is another thing to maintain and goes against general best practices similar to point 1.

These solutions seem needless complicated for a problem that doesn't need to be fixed right now. The easiest, safest and most transparent solution is to use strings, and let end users decide if they want to parse that string. This is also most in line with our SDK approach for both go-denvr and denvrpy.

https://github.com/oapi-codegen/oapi-codegen/issues/891