### PR TITLE
Re-add retries globally

### DIFF
--- a/api/v1/servers/applications/applications.gen.go
+++ b/api/v1/servers/applications/applications.gen.go
@@ -399,16 +399,10 @@ type Client struct {
 func NewClient() Client {
 	conf := config.NewConfig()
 
-	// Use a retryable http client and set the max retries
-	// TODO: re-enable this and call client.Standard() below when we stop
-	// returning incorrect 500 errors
-	// client := retryablehttp.NewClient()
-	// client.RetryMax = int(conf.Retries)
-
 	// Create the client with our server, retryable client and auth intercept method
 	return Client{
 		Server:         conf.Server,
-		Client:         http.DefaultClient,
+		Client:         conf.Client,
 		RequestEditors: []RequestEditorFn{conf.Auth.Intercept},
 	}
 }

--- a/api/v1/servers/virtual/virtual.gen.go
+++ b/api/v1/servers/virtual/virtual.gen.go
@@ -318,16 +318,10 @@ type Client struct {
 func NewClient() Client {
 	conf := config.NewConfig()
 
-	// Use a retryable http client and set the max retries
-	// TODO: re-enable this and call client.Standard() below when we stop
-	// returning incorrect 500 errors
-	// client := retryablehttp.NewClient()
-	// client.RetryMax = int(conf.Retries)
-
 	// Create the client with our server, retryable client and auth intercept method
 	return Client{
 		Server:         conf.Server,
-		Client:         http.DefaultClient,
+		Client:         conf.Client,
 		RequestEditors: []RequestEditorFn{conf.Auth.Intercept},
 	}
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -32,15 +32,21 @@ func TestAuth(t *testing.T) {
 	t.Run(
 		"NewAuth",
 		func(t *testing.T) {
-			assert.Equal(
-				t,
-				auth.Auth{server.URL, "access1", "refresh", time.Now().Unix() + 60, time.Now().Unix() + 3600},
-				auth.NewAuth(
-					server.URL,
-					"alice@denvrtest.com",
-					"alice.is.the.best",
-				),
+			httpClient := &http.Client{}
+			result := auth.NewAuth(
+				server.URL,
+				"alice@denvrtest.com",
+				"alice.is.the.best",
+				httpClient,
 			)
+
+			assert.Equal(t, server.URL, result.Server)
+			assert.Equal(t, "access1", result.AccessToken)
+			assert.Equal(t, "refresh", result.RefreshToken)
+			assert.NotNil(t, result.Client)
+			// Allow some tolerance for timing differences
+			assert.InDelta(t, time.Now().Unix()+60, result.AccessExpires, 5)
+			assert.InDelta(t, time.Now().Unix()+3600, result.RefreshExpires, 5)
 		},
 	)
 }

--- a/templates/client.tmpl
+++ b/templates/client.tmpl
@@ -31,16 +31,10 @@ type {{ $clientTypeName }} struct {
 func NewClient() {{ $clientTypeName }} {
 	conf := config.NewConfig()
 
-	// Use a retryable http client and set the max retries
-	// TODO: re-enable this and call client.Standard() below when we stop
-	// returning incorrect 500 errors
-	// client := retryablehttp.NewClient()
-	// client.RetryMax = int(conf.Retries)
-
     // Create the client with our server, retryable client and auth intercept method
     return {{ $clientTypeName }}{
         Server: conf.Server,
-        Client: http.DefaultClient,
+        Client: conf.Client,
         RequestEditors: []RequestEditorFn{conf.Auth.Intercept},
     }
 }


### PR DESCRIPTION
1. Load the retries value from the config
2. Use the same retryable http client for both auth and api clients
3. Set conservative values for wait and timeout values

We're re-enabling this since we have been hitting some 429 and 500 errors while deploying many apps or vms with terraform.

There are still issues with input validation returning 500s that still need to be fixed.

github.com/denvrdata/DenvrDashboard/issues/3051